### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple 3 button menu with a nice presentation and dismissal animation that is 
 ![One Buttons](http://ploverproductions.com/images/TJLBarButtonMenuR.png?raw=true)
 <h2>Installation</h2>
 <hr>
-Use [Cocoapods](http://www.cocoapods.org), `pod 'TJLBarButtonMenu', '1.0.0'`, or just grab the source folder and drop it into your project.
+Use [CocoaPods](http://www.cocoapods.org), `pod 'TJLBarButtonMenu', '1.0.0'`, or just grab the source folder and drop it into your project.
 <h2>Usage</h2>
 <hr>
 `+initWithViewController:images:buttonTitles:position:`<br>


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
